### PR TITLE
Fixed a major bug

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -60,7 +60,7 @@ else
 fi
 
 # === 6. Set Up Cron Job ===
-echo "*/$minutes * * * * /data/local/tmp/au.sh" >> /data/cron/root
+echo "*/$minutes * * * * /data/local/tmp/au.sh" > /data/cron/root
 chmod 600 /data/cron/root
 
 # === 7. Initialize Logging ===


### PR DESCRIPTION
You see, this file is ONLY used by this program, therefore it needs to contain just 1 line. With the old approach, a line was added every boot, causing immense data and CPU usage every time cron runs, after a while. Closes #3